### PR TITLE
Add Content-Length to avoid chunked data POST

### DIFF
--- a/server/javascripts/services.js
+++ b/server/javascripts/services.js
@@ -63,7 +63,8 @@ OrderService.prototype = {
             path: seller.path,
             method: 'POST',
             headers: {
-                'Content-Type': 'application/json'
+                'Content-Type': 'application/json',
+                'Content-Length' : orderStringified.length
             }
         };
         var request = this.http.request(options, cashUpdater);


### PR DESCRIPTION
This will avoid to have chunked data post. More web servers car handle chunked data correctly, but for those of us who want to write bare metal TCP servers, this should be a bit easier without chunked data ;-)
