### PR TITLE
Improvements for Racket client

### DIFF
--- a/clients/racket/README.md
+++ b/clients/racket/README.md
@@ -18,3 +18,8 @@ You can start your TDD loops.
 To start a web server for the application, run:
 
     $ racket -tm web-server.rkt
+	
+You can save the output in a log file with the ```tee``` command:
+
+    $ racket -tm web-server.rkt | tee -a log.txt
+


### PR DESCRIPTION
Fix the bugs observed durint the last friday session.

The problem was on the Racket web-server which was filtering ip adresses of requests, and accepting only those posted on hostname. It will now accept any requests, including the ones with ip addresses of the client, instead of its hostname.

Added support for ```/ping``` and ```/feedback``` paths.