### PR TITLE
configurable penalty on each iteration when a seller is offline

### DIFF
--- a/server/javascripts/routes.js
+++ b/server/javascripts/routes.js
@@ -40,5 +40,16 @@ module.exports = function (sellerService, dispatcher) {
     }
   });
 
+  router.post('/offlinePenalty', function(request, response) {
+    var penalty = request.body.penalty;
+
+    if (! _.isNumber(penalty)) {
+      response.status(BAD_REQUEST).send({message:'penalty is missing or is not a number'});
+    } else {
+      dispatcher.updateOfflinePenalty(penalty);
+      response.status(OK).end();
+    }
+  });
+
   return router;
 };

--- a/server/javascripts/services/seller.js
+++ b/server/javascripts/services/seller.js
@@ -83,8 +83,13 @@ service.updateCash = function (seller, expectedBill, actualBill, currentIteratio
   }
 }
 
-service.setOffline = function (seller) {
+service.setOffline = function (seller, offlinePenalty, currentIteration) {
   this.sellers.setOffline(seller.name);
+
+  if(offlinePenalty !== 0) {
+    console.info('Seller ' + seller.name + ' is offline: a penalty of ' + offlinePenalty + ' is applied');
+    this.deductCash(seller, offlinePenalty, currentIteration);
+  }
 }
 
 service.setOnline = function (seller) {

--- a/server/specs/services_spec.js
+++ b/server/specs/services_spec.js
@@ -57,6 +57,17 @@ describe('Seller Service', function() {
         expect(sellerService.allSellers()).toContain({name: 'bob', cash: -50})
     });
 
+    it('should deduct a penalty when a seller is offline', function(){
+        var bob = {name: 'bob', cash: 200, online: true};
+        var offlinePenalty = 100;
+        sellers.save(bob);
+
+        sellerService.setOffline(bob, offlinePenalty);
+
+        expect(bob.online).toBe(false);
+        expect(bob.cash).toBe(100);
+    });
+
     it('should compare seller\'s response with expected one using precision 2', function() {
         var bob = {name: 'bob', cash: 0};
         sellers.save(bob);


### PR DESCRIPTION
I hope you will enjoy it.

**Enable €100 penalty on each iteration when offline:** 
```
curl -XPOST -H 'Content-Type: application/json'  http://myGameServer:3000/offlinePenalty -d '{"penalty":100}'
```
This setting was just fine for us when we experimented it. There was an immediate reaction of people that dit not delivered anything. That was fun to observe :-)

**Enable €1000 penalty:**
```
curl -XPOST -H 'Content-Type: application/json'  http://myGameServer:3000/offlinePenalty -d '{"penalty":1000}'
```
This setting would be too high I think. This is just an example. But hey, we could try it anyway ;-)

**Disable penalty:**
```
curl -XPOST -H 'Content-Type: application/json'  http://myGameServer:3000/offlinePenalty -d '{"penalty":0}'
```

I would suggest a small documentation on admin command like this one or reduction changers. I can write it if you want. Not into the readme intended for players of course :-)
