### PR TITLE
Bad request

### DIFF
--- a/server/configuration.json
+++ b/server/configuration.json
@@ -1,4 +1,10 @@
 {
   "reduction": "STANDARD",
-  "offlinePenalty": 0
+  "offlinePenalty": 0,
+
+  "badRequest": {
+    "active": false,
+    "period": 5,
+    "modes": [0,1,2,3,4,5,6,7,8,9,10]
+  }
 }

--- a/server/javascripts/config.js
+++ b/server/javascripts/config.js
@@ -1,6 +1,7 @@
 var fs = require('fs'),
     utils = require('../javascripts/utils'),
-    _ = require('lodash');
+    _ = require('lodash'),
+    colors = require('colors');
 
 var Configuration = function (filepath) {
     this.filepath = filepath;
@@ -9,7 +10,7 @@ var Configuration = function (filepath) {
 
 Configuration.prototype = (function () {
     function loadFile(self, callback) {
-        console.info('Reloading %s.', self.filepath);
+        console.info(colors.red('Reloading ' + self.filepath));
 
         fs.readFile(self.filepath, function (err, data) {
             if (err) {

--- a/server/javascripts/services/index.js
+++ b/server/javascripts/services/index.js
@@ -7,5 +7,6 @@ var utils = require('../utils');
 exports.SellerService = require('./seller');
 exports.OrderService = require('./order');
 exports.Reduction = require('./reduction');
-exports.Dispatcher = require('./dispatcher');
+exports.Dispatcher = require('./dispatcher').Dispatcher;
+exports.BadRequest = require('./dispatcher').BadRequest;
 

--- a/server/javascripts/services/order.js
+++ b/server/javascripts/services/order.js
@@ -1,7 +1,8 @@
 var repositories = require('../repositories');
 var countries = new repositories.Countries();
 var _ = require('lodash');
-var utils = require('../utils');
+var utils = require('../utils'),
+    colors = require('colors');
 
 module.exports = OrderService;
 
@@ -10,7 +11,7 @@ function OrderService () {}
 var service = OrderService.prototype;
 
 service.sendOrder = function (seller, order, cashUpdater, logError) {
-  console.info('Sending order ' + utils.stringify(order) + ' to seller ' + utils.stringify(seller));
+  console.info(colors.grey('Sending order ' + utils.stringify(order) + ' to seller ' + utils.stringify(seller)));
   utils.post(seller.hostname, seller.port, seller.path + '/order', order, cashUpdater, logError);
 };
 

--- a/server/specs/services_spec.js
+++ b/server/specs/services_spec.js
@@ -208,12 +208,32 @@ describe('Dispatcher', function() {
     });
 
     it('should load configuration for reductions', function() {
-        spyOn(configuration, 'all').andReturn({reduction: 'HALF PRICE'});
+        spyOn(configuration, 'all').andReturn({reduction: 'HALF PRICE',
+            badRequest: {
+                active:false
+            }
+        });
         spyOn(dispatcher, 'sendOrderToSellers').andCallFake(function(){});
 
         dispatcher.startBuying(1);
 
-        expect(dispatcher.sendOrderToSellers).toHaveBeenCalledWith(Reduction.HALF_PRICE, 1);
+        expect(dispatcher.sendOrderToSellers).toHaveBeenCalledWith(Reduction.HALF_PRICE, 1, false);
+    });
+
+
+    it('should broadcast a bad request', function() {
+        spyOn(configuration, 'all').andReturn({
+            reduction: 'HALF PRICE',
+            badRequest: {
+                active:true,
+                period:2
+            }
+        });
+        spyOn(dispatcher, 'sendOrderToSellers').andCallFake(function(){});
+
+        dispatcher.startBuying(2);
+
+        expect(dispatcher.sendOrderToSellers).toHaveBeenCalledWith(Reduction.HALF_PRICE, 2, true);
     });
 
     it('should send the same order to each seller using reduction', function() {
@@ -234,17 +254,21 @@ describe('Dispatcher', function() {
 });
 
 describe('BadRequest', function(){
-    var badRequest, sellerService, sellers;
+    var badRequest, sellerService, sellers, configuration;
 
     beforeEach(function(){
+        configuration = new Configuration();
         sellers = new Sellers();
         sellerService = new SellerService(sellers);
-        badRequest = new BadRequest();
+        badRequest = new BadRequest(configuration);
     });
 
     it('should suggest bad request periodically', function() {
-        badRequest.sendBadRequest = true;
-        badRequest.sendBadRequestPeriod = 3;
+        spyOn(configuration, 'all').andReturn({badRequest: {
+            active: true,
+            period: 3,
+            modes: [1,2,3,4,5,6,7,8,9,10]
+        }});
 
         expect(badRequest.shouldSendBadRequest(1)).toEqual(false);
         expect(badRequest.shouldSendBadRequest(2)).toEqual(false);
@@ -255,8 +279,11 @@ describe('BadRequest', function(){
     });
 
     it('should not suggest bad request if not activated', function() {
-        badRequest.sendBadRequest = false;
-        badRequest.sendBadRequestPeriod = 3;
+        spyOn(configuration, 'all').andReturn({badRequest: {
+            active: false,
+            period: 3,
+            modes: [1,2,3,4,5,6,7,8,9,10]
+        }});
 
         expect(badRequest.shouldSendBadRequest(1)).toEqual(false);
         expect(badRequest.shouldSendBadRequest(2)).toEqual(false);
@@ -267,6 +294,10 @@ describe('BadRequest', function(){
     });
 
     it('should randomly corrupt order', function() {
+        spyOn(configuration, 'all').andReturn({badRequest: {
+            modes: [1,2,3,4,5,6,7,8,9,10]
+        }});
+
         var order =  {
             "prices":[64.73,29.48,73.49,58.88,46.61,65.4,16.23],
             "quantities":[8,3,10,6,5,9,5],

--- a/server/specs/services_spec.js
+++ b/server/specs/services_spec.js
@@ -7,6 +7,7 @@ var utils = require('../javascripts/utils');
 var http = require('http');
 
 var Dispatcher = services.Dispatcher;
+var BadRequest = services.BadRequest;
 var OrderService = services.OrderService;
 var SellerService = services.SellerService;
 var Reduction = services.Reduction;
@@ -230,6 +231,87 @@ describe('Dispatcher', function() {
         expect(orderService.sendOrder).toHaveBeenCalledWith(alice, order, jasmine.any(Function), jasmine.any(Function));
         expect(orderService.sendOrder).toHaveBeenCalledWith(bob, order, jasmine.any(Function), jasmine.any(Function));
     });
+});
+
+describe('BadRequest', function(){
+    var badRequest, sellerService, sellers;
+
+    beforeEach(function(){
+        sellers = new Sellers();
+        sellerService = new SellerService(sellers);
+        badRequest = new BadRequest();
+    });
+
+    it('should suggest bad request periodically', function() {
+        badRequest.sendBadRequest = true;
+        badRequest.sendBadRequestPeriod = 3;
+
+        expect(badRequest.shouldSendBadRequest(1)).toEqual(false);
+        expect(badRequest.shouldSendBadRequest(2)).toEqual(false);
+        expect(badRequest.shouldSendBadRequest(3)).toEqual(true);
+        expect(badRequest.shouldSendBadRequest(4)).toEqual(false);
+        expect(badRequest.shouldSendBadRequest(6)).toEqual(true);
+        expect(badRequest.shouldSendBadRequest(7)).toEqual(false);
+    });
+
+    it('should not suggest bad request if not activated', function() {
+        badRequest.sendBadRequest = false;
+        badRequest.sendBadRequestPeriod = 3;
+
+        expect(badRequest.shouldSendBadRequest(1)).toEqual(false);
+        expect(badRequest.shouldSendBadRequest(2)).toEqual(false);
+        expect(badRequest.shouldSendBadRequest(3)).toEqual(false);
+        expect(badRequest.shouldSendBadRequest(4)).toEqual(false);
+        expect(badRequest.shouldSendBadRequest(6)).toEqual(false);
+        expect(badRequest.shouldSendBadRequest(7)).toEqual(false);
+    });
+
+    it('should randomly corrupt order', function() {
+        var order =  {
+            "prices":[64.73,29.48,73.49,58.88,46.61,65.4,16.23],
+            "quantities":[8,3,10,6,5,9,5],
+            "country":"FR",
+            "reduction":"STANDARD"
+        };
+
+        var corrupted1 = badRequest.corruptOrder(order);
+        var corrupted2 = badRequest.corruptOrder(order);
+
+        expect(corrupted1).not.toEqual(order);
+        expect(corrupted2).not.toEqual(order);
+        expect(corrupted1).not.toEqual(corrupted2);
+    });
+
+    it('should deduct cash if response status is not "bad request"', function() {
+        var self = {sellerService: sellerService},
+            seller = {name: "alice", cash: 200},
+            expectedBill={total:47},
+            currentIteration = 17;
+        spyOn(sellerService, 'deductCash');
+        spyOn(sellerService, 'notify');
+
+        var fun = badRequest.updateSellersCash(self, seller, expectedBill, currentIteration);
+
+        fun({statusCode: 200});
+
+        expect(sellerService.deductCash).toHaveBeenCalledWith(seller, 23.5, currentIteration);
+    });
+    
+    it('should add cash if response status is "bad request"', function() {
+        var self = {sellerService: sellerService},
+            seller = {name: "alice", cash: 200},
+            expectedBill={total:47},
+            currentIteration = 17;
+        spyOn(sellerService, 'addCash');
+        spyOn(sellerService, 'notify');
+
+        var fun = badRequest.updateSellersCash(self, seller, expectedBill, currentIteration);
+
+        fun({statusCode: 400});
+
+        expect(sellerService.addCash).toHaveBeenCalledWith(seller, 47, currentIteration);
+    });
+
 });
 
 describe('Standard Reduction', function() {


### PR DESCRIPTION
resolve #53,
If active, bad requests are sent periodically. The current implementation tries to corrupt the original `order` by removing elements from array, replacing values by invalid ones... see `BadRequest.corruptOrder` hard coded corruption modes can be activated or not.

configuration is enhanced with the following:

```json
{
...
  "badRequest": {
    "active": false,
    "period": 5,
    "modes": [0,1,2,3,4,5,6,7,8,9,10]
  }
}
```