### PR TITLE
Dynamic tax rules

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -10,10 +10,10 @@ var routes = require('./javascripts/routes');
 var config = require('./javascripts/config');
 
 
+var configuration = new config.Configuration(CONFIGURATION_FILE);
 var sellers = new repositories.Sellers();
 var sellerService = new services.SellerService(sellers);
-var orderService = new services.OrderService();
-var configuration = new config.Configuration(CONFIGURATION_FILE);
+var orderService = new services.OrderService(configuration);
 var dispatcher = new services.Dispatcher(sellerService, orderService, configuration);
 
 var app = express();

--- a/server/configuration.json
+++ b/server/configuration.json
@@ -6,5 +6,9 @@
     "active": false,
     "period": 5,
     "modes": [0,1,2,3,4,5,6,7,8,9,10]
+  },
+
+  "taxes": {
+    "SK": "function(price) { if(price>2000) return price * 1.2; else return price * 1.1; }"
   }
 }

--- a/server/javascripts/repositories.js
+++ b/server/javascripts/repositories.js
@@ -99,14 +99,17 @@ Sellers.prototype = (function(){
     }
 })();
 
-var Countries = function() {};
+var Countries = function(configuration) {
+    this.configuration = configuration;
+};
 
 Countries.prototype = (function() {
     var Country = function(name, taxRule) {
         this.name = name;
         this.taxRule = taxRule;
-        var self = this;
-        this.applyTax = function(sum) { return self.taxRule.apply(self, [sum]); }
+    };
+    Country.prototype = {
+        applyTax : function(sum) { return this.taxRule.apply(this, [sum]); }
     };
 
     var europeanCountries = {
@@ -172,7 +175,7 @@ Countries.prototype = (function() {
     };
 })();
 
-var exports = module.exports;
-
-exports.Sellers = Sellers;
-exports.Countries = Countries;
+module.exports = {
+    Sellers: Sellers,
+    Countries: Countries
+};

--- a/server/javascripts/services/order.js
+++ b/server/javascripts/services/order.js
@@ -1,12 +1,13 @@
 var repositories = require('../repositories');
-var countries = new repositories.Countries();
 var _ = require('lodash');
 var utils = require('../utils'),
     colors = require('colors');
 
-module.exports = OrderService;
+function OrderService (configuration) {
+  this.countries = new repositories.Countries(configuration);
+}
 
-function OrderService () {}
+module.exports = OrderService;
 
 var service = OrderService.prototype;
 
@@ -19,6 +20,7 @@ service.createOrder = function (reduction) {
   var items = _.random(1, 10);
   var prices = new Array(items);
   var quantities = new Array(items);
+  var country = this.countries.randomOne();
 
   for(var item = 0; item < items; item++) {
     var price = _.random(1, 100, true);
@@ -29,7 +31,7 @@ service.createOrder = function (reduction) {
   return {
     prices: prices,
     quantities: quantities,
-    country: countries.randomOne(),
+    country: country,
     reduction: reduction.name
   };
 };
@@ -41,7 +43,7 @@ service.bill = function (order, reduction) {
     .map(function(q, i) {return q * prices[i]})
     .reduce(function(sum, current) {return sum + current}, 0);
 
-  var taxRule = countries.taxRule(order.country);
+  var taxRule = this.countries.taxRule(order.country);
   sum = taxRule.applyTax(sum);
   sum = reduction.apply(sum);
   return { total: sum };

--- a/server/specs/app_integration_spec.js
+++ b/server/specs/app_integration_spec.js
@@ -7,11 +7,12 @@ var _ = require('lodash'),
     //
     routes = require('../javascripts/routes'),
     services = require('../javascripts/services'),
-    repositories = require('../javascripts/repositories');
+    repositories = require('../javascripts/repositories'),
+    Configuration = require('../javascripts/config').Configuration;
 
 
 describe('Route', function () {
-    var sellers, dispatcher, sellerService, orderService;
+    var sellers, dispatcher, sellerService, orderService, configuration;
     var app;
 
     var done, error, grabError = function (err, res) {
@@ -24,10 +25,11 @@ describe('Route', function () {
     };
 
     beforeEach(function () {
+        configuration = new Configuration();
         sellers = new repositories.Sellers();
         sellerService = new services.SellerService(sellers);
-        orderService = new services.OrderService();
-        dispatcher = new services.Dispatcher(sellerService, orderService);
+        orderService = new services.OrderService(configuration);
+        dispatcher = new services.Dispatcher(sellerService, orderService, configuration);
 
         app = express();
         app.use(bodyParser.json());

--- a/server/specs/investigating_spec.js
+++ b/server/specs/investigating_spec.js
@@ -1,0 +1,13 @@
+
+describe('Configuration', function(){
+   it('should evaluate function from string', function() {
+       var customEval = function(s) { return new Function("return " + s)(); },
+           str1 = "function (price) { return price - 50; }",
+           fun1 = customEval(str1),
+           str2 = "function (price) { return price / 2; }",
+           fun2 = customEval(str2);
+
+       expect(fun1.apply(null, [124])).toEqual(74);
+       expect(fun2.apply(null, [124])).toEqual(62);
+   })
+});

--- a/server/specs/repositories_spec.js
+++ b/server/specs/repositories_spec.js
@@ -96,11 +96,11 @@ describe('Countries', function() {
 
     beforeEach(function() {
         configuration = new Configuration();
-        spyOn(configuration, 'all').andReturn({});
         countries = new Countries(configuration);
     });
 
     it('should get the corresponding tax for a given country', function() {
+        spyOn(configuration, 'all').andReturn({});
         expect(countries.taxRule('DE').applyTax(1)).toBe(1.2);
         expect(countries.taxRule('UK').applyTax(1)).toBe(1.21);
         expect(countries.taxRule('FR').applyTax(1)).toBe(1.2);
@@ -132,6 +132,7 @@ describe('Countries', function() {
     });
 
     it('should get the updated tax for a given country', function() {
+        spyOn(configuration, 'all').andReturn({});
     	var newTaxRule = function(total) { if(total > 100) return total * 1.2; else return total * 1.2 + 100; };
 	    countries.updateTax('FR', newTaxRule);
 
@@ -142,6 +143,7 @@ describe('Countries', function() {
     });
 
     it('should return random country according to its frequency', function() {
+        spyOn(configuration, 'all').andReturn({});
         var mostImportantPopulation = 200000,
             samples = _.times(mostImportantPopulation * 10, countries.randomOne);
 
@@ -151,6 +153,46 @@ describe('Countries', function() {
         expect(_.size(occurrences['UK'])).toBeGreaterThan(152741);
         expect(_.size(occurrences['LT'])).toBeLessThan(6844 * 10);
         expect(_.size(occurrences['NL'])).toBeLessThan(39842 * 10);
+    });
+
+    it('should return tax modified from configuration - percentage case', function() {
+        spyOn(configuration, 'all').andReturn({taxes: {
+            'LU': 3.44
+        }});
+
+        var newTax = countries.taxRule('LU');
+
+        expect(newTax.applyTax(100)).toBe(100 * 3.44);
+    });
+
+    it('should return tax modified from configuration - function case', function() {
+        spyOn(configuration, 'all').andReturn({taxes: {
+            'CY': "function(price) { return 1234; }"
+        }});
+
+        var newTax = countries.taxRule('CY');
+
+        expect(newTax.applyTax(421)).toBe(1234);
+    });
+
+    it('should keep tax unchanged when it fails to read it from configuration - invalid function case', function() {
+        spyOn(configuration, 'all').andReturn({taxes: {
+            'EE': "funn(price) {return unprobableVariable*7;}",
+            'LV': "function(price) return 4",
+            'SI': "45"
+        }});
+
+        expect(countries.taxRule('EE').applyTax(231)).toBe(231 * 1.22);
+        expect(countries.taxRule('LV').applyTax(232)).toBe(232 * 1.2);
+        expect(countries.taxRule('SI').applyTax(233)).toBe(233 * 1.24);
+    });
+
+    it('should keep tax unchanged when it fails to execute evaluation from configuration', function() {
+        spyOn(configuration, 'all').andReturn({taxes: {
+            'EE': "function(price) {return 7;}"
+        }});
+
+        expect(countries.taxRule('EE').applyTax(231)).toBe(231 * 1.22);
     });
 });
 

--- a/server/specs/repositories_spec.js
+++ b/server/specs/repositories_spec.js
@@ -5,6 +5,7 @@ var repositories = require('../javascripts/repositories'),
 var Sellers = repositories.Sellers;
 var Countries = repositories.Countries;
 var Reductions = repositories.Reductions;
+var Configuration = require('../javascripts/config').Configuration;
 
 describe('Sellers', function(){
     var bob;
@@ -91,10 +92,11 @@ describe('Sellers', function(){
 });
 
 describe('Countries', function() {
-    var countries;
+    var countries, configuration;
 
     beforeEach(function() {
-        countries = new Countries();
+        configuration = new Configuration();
+        countries = new Countries(configuration);
     });
 
     it('should get the corresponding tax for a given country', function() {

--- a/server/specs/repositories_spec.js
+++ b/server/specs/repositories_spec.js
@@ -96,6 +96,7 @@ describe('Countries', function() {
 
     beforeEach(function() {
         configuration = new Configuration();
+        spyOn(configuration, 'all').andReturn({});
         countries = new Countries(configuration);
     });
 

--- a/server/specs/services_spec.js
+++ b/server/specs/services_spec.js
@@ -166,6 +166,7 @@ describe('Order Service', function() {
     });
 
     it('should calculate the sum of the order using PAY_THE_PRICE reduction', function() {
+        spyOn(configuration, 'all').andReturn({});
         var order = {prices: [1000, 50], quantities: [1, 2], country: 'IT'};
 
         var bill = orderService.bill(order, Reduction.PAY_THE_PRICE);
@@ -174,6 +175,7 @@ describe('Order Service', function() {
     });
 
     it('should calculate the sum of the order using STANDARD reduction', function() {
+        spyOn(configuration, 'all').andReturn({});
         var order = {prices: [1000, 50], quantities: [1, 2], country: 'IT'};
 
         var bill = orderService.bill(order, Reduction.STANDARD);
@@ -182,6 +184,7 @@ describe('Order Service', function() {
     });
 
     it('should calculate the sum of the order using HALF_PRICE reduction', function() {
+        spyOn(configuration, 'all').andReturn({});
         var order = {prices: [1000, 50], quantities: [1, 2], country: 'IT'};
 
         var bill = orderService.bill(order, Reduction.HALF_PRICE);
@@ -238,6 +241,8 @@ describe('Dispatcher', function() {
     });
 
     it('should send the same order to each seller using reduction', function() {
+        spyOn(configuration, 'all').andReturn({});
+
         var alice = {name: 'alice', hostname : 'seller', port : '8080', path : '/', cash: 0};
         var bob = {name: 'bob', hostname : 'seller', port : '8081', path : '/', cash: 0};
         spyOn(sellerService, 'addCash');

--- a/server/specs/services_spec.js
+++ b/server/specs/services_spec.js
@@ -118,12 +118,13 @@ describe('Seller Service', function() {
 });
 
 describe('Order Service', function() {
-    var orderService;
+    var orderService, configuration;
     var countries;
 
     beforeEach(function(){
-        orderService = new OrderService();
-        countries = new Countries();
+        configuration = new Configuration();
+        orderService = new OrderService(configuration);
+        countries = new Countries(configuration);
     });
 
     it('should send order to seller', function() {
@@ -201,9 +202,9 @@ describe('Dispatcher', function() {
     var dispatcher, orderService, sellerService, configuration;
 
     beforeEach(function(){
-        sellerService = new SellerService();
-        orderService = new OrderService();
         configuration = new Configuration();
+        sellerService = new SellerService();
+        orderService = new OrderService(configuration);
         dispatcher = new Dispatcher(sellerService, orderService, configuration);
     });
 


### PR DESCRIPTION
Resolve #52 - allow to dynamically change tax rule calculation based on configuration.
Configuration allow scale factor or function definition.

Configuration example:

```json
{
   ...
   
  "taxes": {
    "SK": "function(price) { if(price>2000) return price * 1.2; else return price * 1.1; }",
    "UK": 1.45
  }
}
```