### PR TITLE
update scala client to last scala version

### DIFF
--- a/clients/scala/.gitignore
+++ b/clients/scala/.gitignore
@@ -1,3 +1,3 @@
 .idea
 target
-project
+project/target

--- a/clients/scala/build.sbt
+++ b/clients/scala/build.sbt
@@ -7,5 +7,7 @@ lazy val root = (project in file(".")).
       version      := "1.0"
     )),
     name := "scala",
-    libraryDependencies += `akka-http`
+    libraryDependencies += `akka-http`,
+    libraryDependencies += `akka-http-circe`,
+    libraryDependencies += `circe-generic`
   )

--- a/clients/scala/build.sbt
+++ b/clients/scala/build.sbt
@@ -1,13 +1,14 @@
-name := "scala"
+import Dependencies._
 
-version := "1.0"
-
-scalaVersion := "2.11.6"
-
-libraryDependencies += "io.spray" %% "spray-routing" % "1.3.2"
-
-libraryDependencies += "io.spray" %% "spray-can" % "1.3.2"
-
-libraryDependencies += "com.typesafe.akka" %% "akka-actor" % "2.3.9"
-
-libraryDependencies += "com.typesafe.play" %% "play-json" % "2.4.0-M2"
+lazy val root = (project in file(".")).
+  settings(
+    inThisBuild(List(
+      scalaVersion := "2.11.6",
+      version      := "1.0"
+    )),
+    name := "scala",
+    libraryDependencies += `spray-routing`,
+    libraryDependencies += `spray-can`,
+    libraryDependencies += `akka-actor`,
+    libraryDependencies += `play-json`
+  )

--- a/clients/scala/build.sbt
+++ b/clients/scala/build.sbt
@@ -3,12 +3,9 @@ import Dependencies._
 lazy val root = (project in file(".")).
   settings(
     inThisBuild(List(
-      scalaVersion := "2.11.6",
+      scalaVersion := "2.12.2",
       version      := "1.0"
     )),
     name := "scala",
-    libraryDependencies += `spray-routing`,
-    libraryDependencies += `spray-can`,
-    libraryDependencies += `akka-actor`,
-    libraryDependencies += `play-json`
+    libraryDependencies += `akka-http`
   )

--- a/clients/scala/project/Dependencies.scala
+++ b/clients/scala/project/Dependencies.scala
@@ -1,8 +1,5 @@
 import sbt._
 
 object Dependencies {
-  lazy val `spray-routing`: ModuleID = "io.spray" %% "spray-routing" % "1.3.2"
-  lazy val `spray-can`: ModuleID = "io.spray" %% "spray-can" % "1.3.2"
-  lazy val `akka-actor`: ModuleID = "com.typesafe.akka" %% "akka-actor" % "2.3.9"
-  lazy val `play-json`: ModuleID = "com.typesafe.play" %% "play-json" % "2.4.0-M2"
+  lazy val `akka-http`: ModuleID = "com.typesafe.akka" %% "akka-http" % "10.0.9"
 }

--- a/clients/scala/project/Dependencies.scala
+++ b/clients/scala/project/Dependencies.scala
@@ -1,0 +1,8 @@
+import sbt._
+
+object Dependencies {
+  lazy val `spray-routing`: ModuleID = "io.spray" %% "spray-routing" % "1.3.2"
+  lazy val `spray-can`: ModuleID = "io.spray" %% "spray-can" % "1.3.2"
+  lazy val `akka-actor`: ModuleID = "com.typesafe.akka" %% "akka-actor" % "2.3.9"
+  lazy val `play-json`: ModuleID = "com.typesafe.play" %% "play-json" % "2.4.0-M2"
+}

--- a/clients/scala/project/Dependencies.scala
+++ b/clients/scala/project/Dependencies.scala
@@ -2,4 +2,6 @@ import sbt._
 
 object Dependencies {
   lazy val `akka-http`: ModuleID = "com.typesafe.akka" %% "akka-http" % "10.0.9"
+  lazy val `akka-http-circe`: ModuleID = "de.heikoseeberger" %% "akka-http-circe" % "1.16.1"
+  lazy val `circe-generic`: ModuleID = "io.circe" %% "circe-generic" % "0.8.0"
 }

--- a/clients/scala/project/build.properties
+++ b/clients/scala/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.5
+sbt.version = 0.13.15

--- a/clients/scala/project/plugins.sbt
+++ b/clients/scala/project/plugins.sbt
@@ -1,1 +1,0 @@
-logLevel := Level.Warn

--- a/clients/scala/src/main/scala/main/Server.scala
+++ b/clients/scala/src/main/scala/main/Server.scala
@@ -1,19 +1,21 @@
 package main
 
+import akka.http.scaladsl.marshalling.ToResponseMarshallable
+import akka.http.scaladsl.model.ContentTypes.`application/json`
+import akka.http.scaladsl.model.HttpEntity
 import akka.http.scaladsl.server.{HttpApp, Route}
+import de.heikoseeberger.akkahttpcirce.FailFastCirceSupport._
+import io.circe.generic.auto._
 
 case class Order(prices: Seq[Float], quantities: Seq[Int], country: String)
+
+case class Result(total: Float)
+
+case class Feedback(`type`: String, content: String)
 
 object Server extends HttpApp with App {
 
   type ProcessOrder = Order => Option[Float]
-
-  // TODO Modify the server configuration if necessary
-  val address = "localhost"
-  val port: Int = 9000
-
-  val orderRoute = "order"
-  val feedbackRoute = "feedback"
 
   lazy val process: ProcessOrder = {
     // TODO To implement
@@ -21,35 +23,30 @@ object Server extends HttpApp with App {
   }
 
   override def routes: Route =
-    path(orderRoute) {
+    path("order") {
       post {
-        entity(as[String]) {
-          order =>
-            complete {
+        entity(as[Order]) { order =>
+          complete {
+            println("Request received : " + order)
 
-              println("Request received : " + order)
+            val total = process(order)
 
-              // TODO To implement
-              val total = 0
-
-              s"""{
-                 |"total": $total
-                  }""".stripMargin
-            }
+            Result(total.getOrElse(0f))
+          }
         }
       }
     } ~
       path("feedback") {
         post {
-          entity(as[String]) {
-            feedback =>
-              complete {
-                println("Feedback received : " + feedback)
-                ""
-              }
+          entity(as[Feedback]) { feedback =>
+            complete {
+              println("Feedback received : " + feedback)
+              ""
+            }
           }
         }
       }
 
-  startServer(host = address, port = port)
+  startServer(host = "0.0.0.0", port = 9000)
+
 }

--- a/clients/scala/src/main/scala/main/Server.scala
+++ b/clients/scala/src/main/scala/main/Server.scala
@@ -1,13 +1,10 @@
 package main
 
-import akka.actor.ActorSystem
-import spray.routing.SimpleRoutingApp
+import akka.http.scaladsl.server.{HttpApp, Route}
 
 case class Order(prices: Seq[Float], quantities: Seq[Int], country: String)
 
-object Server extends App with SimpleRoutingApp {
-
-  implicit val system = ActorSystem("my-system")
+object Server extends HttpApp with App {
 
   type ProcessOrder = Order => Option[Float]
 
@@ -23,10 +20,7 @@ object Server extends App with SimpleRoutingApp {
     order => Some(0.0f)
   }
 
-  startServer(interface = address, port = port) {
-
-    println("Server started @ " + address + ":" + port)
-
+  override def routes: Route =
     path(orderRoute) {
       post {
         entity(as[String]) {
@@ -57,5 +51,5 @@ object Server extends App with SimpleRoutingApp {
         }
       }
 
-  }
+  startServer(host = address, port = port)
 }


### PR DESCRIPTION
This update yields to remove deprecated _spray_ and replace it with a conjonction of _akka-http_ and _circe_ to manage json marshalling.