### PR TITLE
created a setting to enable / disable sending orders to sellers

### DIFF
--- a/server/configuration.json
+++ b/server/configuration.json
@@ -1,4 +1,5 @@
 {
+  "active": true,
   "reduction": "STANDARD",
   "offlinePenalty": 0,
 

--- a/server/specs/services_spec.js
+++ b/server/specs/services_spec.js
@@ -221,6 +221,23 @@ describe('Dispatcher', function() {
         dispatcher = new Dispatcher(sellerService, orderService, configuration);
     });
 
+    it('should not send request to sellers when active config is set to false', function() {
+        spyOn(configuration, 'all').andReturn(
+            {
+                reduction: 'STANDARD',
+                badRequest: {
+                    active:true,
+                    period:2
+                },
+                active: false
+            }
+        );
+        spyOn(dispatcher, 'sendOrderToSellers').andCallFake(function(){});
+
+        expect(dispatcher.startBuying(1)).toEqual(1);
+        expect(dispatcher.sendOrderToSellers).not.toHaveBeenCalled();
+    })
+
     it('should load configuration for reductions', function() {
         spyOn(configuration, 'all').andReturn({reduction: 'HALF PRICE',
             badRequest: {


### PR DESCRIPTION
I noticed that the server starts to send orders to sellers immediately after starting. It should't be a problem, but someone could register and start to collect orders before everyone else. If you think this doesn't make sense, its fine :)
 
A new boolean config called `active` was created. It controls if orders will be sent to sellers or not. I tried to maintain compatibility with previous behaviour, so if the new config is no present it defaults to `true`.

I'm not entirely happy with the config name, but it can start a conversation.