### PR TITLE
Create a parameter to freeze/unfreeze cash updates

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -28,6 +28,25 @@ Before you start an Extreme Carpaccio workshop, it is strongly recommended that 
 1. In the second computer run: `$ nc <IP address of the 1st computer> 3000 | tee `
 1. If the network allows incoming connections, you should see the message `Hello Extreme Carpaccio` appearing in the second computer
 
+## Freeze the game to make everyone start at the same time
+
+People will take time to setup their HTTP server. Some of them will need more time than others, because of setup problems.
+
+As a facilitator, you may want everyone to be ready before starting the game, to be fair with people that had problems.
+
+You can do this this way:
+
+1. Open ``configuration.json`` file 
+1. Replace ``"cashFreeze": false,`` with ``"cashFreeze": true,`` and save
+1. Start the game server with ``npm start``
+1. Make everyone register
+1. Thanks to the ``cashFreeze`` parameter, everyone's cash stays at 0.
+1. Wait until every team is registered **and marked online**. This means the game is setup for everyone.
+1. Say '*Looks like that everyone is ready. Then I will start the game in 5 seconds.*' 
+1. Open ``configuration.json`` file 
+1. Replace ``"cashFreeze": true,`` with ``"cashFreeze": false,`` and save
+1. Player's cash is now evaluated. The game starts!
+
 ## Workshop
 Extreme Carpaccio is intended to be played with Product Owners (PO) and Developers together. It can be played with only Developers, but slicing strategies tend to be more biased since developers generally focus more on code and than on product and iterations.
 

--- a/server/app.js
+++ b/server/app.js
@@ -12,7 +12,7 @@ var config = require('./javascripts/config');
 
 var configuration = new config.Configuration(CONFIGURATION_FILE);
 var sellers = new repositories.Sellers();
-var sellerService = new services.SellerService(sellers);
+var sellerService = new services.SellerService(sellers, configuration);
 var orderService = new services.OrderService(configuration);
 var dispatcher = new services.Dispatcher(sellerService, orderService, configuration);
 

--- a/server/configuration.json
+++ b/server/configuration.json
@@ -1,5 +1,6 @@
 {
   "active": true,
+  "cashFreeze": false,
   "reduction": "STANDARD",
   "offlinePenalty": 0,
 

--- a/server/javascripts/services/seller.js
+++ b/server/javascripts/services/seller.js
@@ -3,8 +3,9 @@ var utils = require('../utils');
 var UrlAssembler = require('url-assembler');
 var _ = require('lodash');
 
-function SellerService (_sellers) {
+function SellerService (_sellers, _configuration) {
   this.sellers = _sellers;
+  this.configuration = _configuration;
 }
 module.exports = SellerService;
 
@@ -75,6 +76,10 @@ service.allSellers = function () {
 };
 
 service.updateCash = function (seller, expectedBill, actualBill, currentIteration) {
+  if(this.configuration.all().cashFreeze) {
+    console.info('Cash was not updated because cashFreeze config parameter is true');
+    return;
+  }
   try {
     var totalExpectedBill = utils.fixPrecision(expectedBill.total, 2);
     var message;

--- a/server/specs/app_integration_spec.js
+++ b/server/specs/app_integration_spec.js
@@ -27,7 +27,7 @@ describe('Route', function () {
     beforeEach(function () {
         configuration = new Configuration();
         sellers = new repositories.Sellers();
-        sellerService = new services.SellerService(sellers);
+        sellerService = new services.SellerService(sellers, configuration);
         orderService = new services.OrderService(configuration);
         dispatcher = new services.Dispatcher(sellerService, orderService, configuration);
 


### PR DESCRIPTION
Teams ready with their setup before the others can earn money before the others. Some players found that unfair, and me too :)
That's difficult to manage when you facilitate the game for a large number of teams at the same time.

So I added a `cashFreeze` parameter. When this config parameter is set to true, teams can register and the server tells who is online or not, but everyone's cash stays the same. When everyone is ready & online, you set the parameter to false. Then every team starts being evaluated at the same time.

I tested it during Devoxx for 15 teams and that did the job perfectly :)

I guess the intent of this PR is the same: https://github.com/dlresende/extreme-carpaccio/pull/83 but when I used the `active: false` parameter I was not able to tell who were online and who were not. I can see that with `cashFreeze`.