### PR TITLE
Small fix on README files

### DIFF
--- a/README-FR.md
+++ b/README-FR.md
@@ -1,6 +1,6 @@
 # Extreme Carpaccio
 
-Version anglaise [ici](https://github.com/dlresende/extreme-carpaccio/tree/master/README.md).
+Version anglaise [ici](./README.md).
 
 L'Extrême Carpccio est un jeu de développement conçu pour encourager et favoriser le développement incrémental et les bonnes pratiques de déploiement continu.
 
@@ -12,9 +12,9 @@ Ce workshop, kata, ou jeu de développement est destiné à aider les équipes �
 
 Prêt à relever le défi ?
 
-Si vous êtes un participant, allez sur [clients/](https://github.com/dlresende/extreme-carpaccio/tree/master/client/README-FR.md) pour avoir les instructions et commencer à jouer.
+Si vous êtes un participant, allez sur [clients/](./clients/README-FR.md) pour avoir les instructions et commencer à jouer.
 
-Si vous êtes un facilitateur, allez sur [server/](https://github.com/dlresende/extreme-carpaccio/tree/master/server/README-FR.md) pour voir comment faciliter une session. 
+Si vous êtes un facilitateur, allez sur [server/](./server/README-FR.md) pour voir comment faciliter une session. 
 
 Amusez-vous bien :D
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Extreme Carpaccio
 
-French version [here](https://github.com/dlresende/extreme-carpaccio/tree/master/README-FR.md).
+French version [here](./README-FR.md).
 
 Extreme Carpaccio is a coding game designed to encourage and favour incremental development and Continuous Delivery best practices.
 
@@ -10,9 +10,9 @@ This workshop, kata, or coding game is intented to help teams to practice concep
 
 Ready for the challenge? 
 
-If you are a **participant**, go to [clients/](https://github.com/dlresende/extreme-carpaccio/tree/master/clients) to get more instructions and start playing.
+If you are a **participant**, go to [clients/](./clients/README.md) to get more instructions and start playing.
 
-If you are a **facilitator**, go to [server/](https://github.com/dlresende/extreme-carpaccio/tree/master/server) and find out how to facilitate a session.
+If you are a **facilitator**, go to [server/](./server/README.md) and find out how to facilitate a session.
 
 Have fun :D
 

--- a/clients/README-FR.md
+++ b/clients/README-FR.md
@@ -1,5 +1,7 @@
 # Instructions for participants
 
+Version anglaise [ici](./README.md).
+
 ## Découpage
 
 Pour calculer le total de la facture, il faut prendre en compte les taxes du pays d'où provient la facture, ainsi que la réduction qu'il convient d'appliquer.

--- a/clients/README.md
+++ b/clients/README.md
@@ -1,5 +1,7 @@
 # Instructions for participants
 
+French version [here](./README-FR.md).
+
 ## Slicing
 
 To calculate the bill, you need to consider the tax of the country from which the order came from and the reduction.

--- a/server/README-FR.md
+++ b/server/README-FR.md
@@ -2,6 +2,8 @@
 
 # Instructions pour les facilitateurs
 
+Version anglaise [ici](./README.md).
+
 ## Dépendances
 
 - [nodejs](https://nodejs.org/en/)

--- a/server/README.md
+++ b/server/README.md
@@ -2,6 +2,8 @@
 
 # Instructions for Facilitators
 
+French version [here](./README-FR.md).
+
 ## Requirements
 - [nodejs](https://nodejs.org/en/)
 


### PR DESCRIPTION
So after my previous pull request, I found out that the path for clients readme was broken... (small typo on my part `/client` instead of `/clients` ...)
I fixed that.

But the reason I let that pass, was I could not test it neither on my fork, neither on my computer.
When the code is on one computer, the links open up internet and not just the right file. So I set the  path to other README files as relative files (so it now works, on GitHub on master repo (hopefully), but also on forked repo, and on local computers) Not sure what the reason was for the hardcoded GitHub path, if there was a reason, no problem I will amend the commit with just the typo fix.

I apologizes for my mistake 🙇‍♂️.