### PR TITLE
Update seller URL path to pathname.

### DIFF
--- a/server/javascripts/services/seller.js
+++ b/server/javascripts/services/seller.js
@@ -62,7 +62,7 @@ service.register = function (sellerUrl, name, password) {
     password: password,
     hostname: parsedUrl.hostname,
     port: parsedUrl.port,
-    path: parsedUrl.path,
+    path: parsedUrl.pathname,
     cash: 0.0,
     online: false,
     url: new UrlAssembler(sellerUrl)


### PR DESCRIPTION
It seems that for a seller url of this type **http://127.0.0.1:80**, the parse of the URL does not fill in the path correctly (`undefined`) when it is not filled in but the pathname is initialized with a non-zero value `/`  
